### PR TITLE
🙉 Add support for an `ignore_list` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ See:
 
 ## Inputs
 
-None.
+| Name | Description | Required | Default |
+|:-:|:-:|:-:|:-:|
+| `ignore_list` | "Space-separated list of CVEs to ignore (e.g., CVE-2023-26141 CVE-2021-41182 CVE-2021-41183)" | false | "" |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,12 @@
 name: "Run Bundler Audit"
 description: "Runs bundle-audit check --update and outputs results."
 
+inputs:
+  ignore_list:
+    description: "Space-separated list of CVEs to ignore (e.g., CVE-2023-26141 CVE-2021-41182 CVE-2021-41183)"
+    required: false
+    default: ""
+
 outputs:
   has_vulnerabilities:
     description: "True if vulnerabilities are found, false otherwise"
@@ -25,7 +31,7 @@ runs:
     - name: Run Bundler Audit
       id: audit
       run: |
-        bundle-audit check --update > audit_output.txt || true
+        bundle-audit check --update --ignore ${{ inputs.ignore_list }} > audit_output.txt || true
       shell: bash
 
     - name: Check for Vulnerabilities


### PR DESCRIPTION
This will allow passing in a space-separated list of CVS identifiers which the check will ignore.