### PR TITLE
Fix: only pass the `--ignore` flag if the `ignore_list` input is not empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Run Bundler Audit
       id: audit
       run: |
-        bundle-audit check --update --ignore ${{ inputs.ignore_list }} > audit_output.txt || true
+        bundle-audit check --update ${${{ inputs.ignore_list }}:+--ignore ${{ inputs.ignore_list }}} > audit_output.txt || true
       shell: bash
 
     - name: Check for Vulnerabilities

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,12 @@ runs:
     - name: Run Bundler Audit
       id: audit
       run: |
-        bundle-audit check --update ${${{ inputs.ignore_list }}:+--ignore ${{ inputs.ignore_list }}} > audit_output.txt || true
+        ignore_flag=""
+        if [ -n "${{ inputs.ignore_list }}" ]; then
+          ignore_flag="--ignore ${{ inputs.ignore_list }}"
+        fi
+
+        bundle-audit check --update $ignore_flag > audit_output.txt || true
       shell: bash
 
     - name: Check for Vulnerabilities


### PR DESCRIPTION
😅 Currently, the `bundle-audit-to-asana-action` is failing when running `bundle-audit-action` with the error:
`No value provided for option '--ignore'`

This just updates the run command to only pass the `ignore` flag if there is a value in the ignore list.

FWIW: I am pretty bad at the github workflow syntax, so if there is a better/cleaner way to do this, then definitely open to suggestions :)

Note:
I don't think we will need to update `bundle-audit-to-asana-action` to point to this new version because it just points to [v1](https://github.com/planningcenter/bundle-audit-to-asana-action/blob/main/action.yml#L19)
